### PR TITLE
feat: flyway v1, v2

### DIFF
--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,35 @@
+CREATE TABLE integration_requests
+(
+    id                   BIGINT AUTO_INCREMENT PRIMARY KEY,
+    request_id           VARCHAR(255) NOT NULL UNIQUE,
+    protocols_requested  VARCHAR(100) NOT NULL,
+    payload              LONGTEXT,
+    status               VARCHAR(20)  NOT NULL,
+    overall_status       VARCHAR(20),
+    created_at           DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    completed_at         DATETIME
+);
+
+CREATE TABLE protocol_results
+(
+    id               BIGINT AUTO_INCREMENT PRIMARY KEY,
+    request_id       VARCHAR(255) NOT NULL,
+    protocol         VARCHAR(50)  NOT NULL,
+    status           VARCHAR(20)  NOT NULL,
+    response_code    VARCHAR(50),
+    response_message TEXT,
+    execution_time_ms BIGINT,
+    created_at       DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at       DATETIME     ON UPDATE CURRENT_TIMESTAMP
+);
+
+CREATE TABLE system_logs
+(
+    id           BIGINT AUTO_INCREMENT PRIMARY KEY,
+    request_id   VARCHAR(255) NOT NULL,
+    protocol     VARCHAR(50),
+    event_type   VARCHAR(100) NOT NULL,
+    event_detail TEXT,
+    timestamp    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_by   VARCHAR(100)
+);

--- a/src/main/resources/db/migration/V2__add_indexes.sql
+++ b/src/main/resources/db/migration/V2__add_indexes.sql
@@ -1,0 +1,13 @@
+-- integration_requests
+CREATE INDEX idx_ir_request_id ON integration_requests (request_id);
+CREATE INDEX idx_ir_status     ON integration_requests (status);
+
+-- protocol_results
+CREATE INDEX idx_pr_request_id      ON protocol_results (request_id);
+CREATE INDEX idx_pr_protocol        ON protocol_results (protocol);
+CREATE INDEX idx_pr_protocol_status ON protocol_results (protocol, status);
+
+-- system_logs
+CREATE INDEX idx_sl_request_id  ON system_logs (request_id);
+CREATE INDEX idx_sl_timestamp   ON system_logs (timestamp);
+CREATE INDEX idx_sl_protocol_ts ON system_logs (protocol, timestamp);


### PR DESCRIPTION

테이블 | 인덱스 | 용도
-- | -- | --
integration_requests | request_id, status | getStatus(), 상태 필터
protocol_results | request_id, protocol, (protocol+status) | 결과 조회, 프로토콜 필터
system_logs | request_id, timestamp, (protocol+timestamp) | 로그 조회, 시간 범위, 프로토콜별 최신순

